### PR TITLE
use signed char on aarch64

### DIFF
--- a/build_lmer_table.c
+++ b/build_lmer_table.c
@@ -130,7 +130,7 @@ int main(int argc, char* argv[])
 int build_sequence(char *sequence, char *filename)
 {
   int i, j;
-  char c;
+  signed char c;
   FILE *fp;
 
   if( (fp = fopen(filename, "r")) == NULL)

--- a/build_repeat_families.c
+++ b/build_repeat_families.c
@@ -713,7 +713,7 @@ void print_parameters()
 int build_sequence(char *sequence, char *filename)
 {
   int i, j, seq;
-  char c;
+  signed char c;
   FILE *fp;
   int boundariesSize = 100;
 


### PR DESCRIPTION
Hello, 

while `char` is signed on x86 it is `unsigned` on aarch64 thus `EOF` is not properly handled whne using char 

regards

Eric